### PR TITLE
Add support for filtering for events from specific calendars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Calendar Focus Sync
+
+## 0.6
+
+- Add support for filtering for events from specific calendars
+- Fixes issue with triggering focus in MacOS 14.4

--- a/Calendar Focus Sync.xcodeproj/project.pbxproj
+++ b/Calendar Focus Sync.xcodeproj/project.pbxproj
@@ -501,7 +501,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Calendar Focus Sync/Calendar_Focus_Sync.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 5;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = UP7DQ4WSUA;
 				ENABLE_PREVIEWS = YES;
@@ -515,7 +515,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.4;
+				MARKETING_VERSION = 0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.andrewglago.Calendar-Focus-Sync";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -533,7 +533,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = UP7DQ4WSUA;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -548,7 +548,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.5;
+				MARKETING_VERSION = 0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.andrewglago.Calendar-Focus-Sync";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Calendar Focus Sync/RELEASE.md
+++ b/Calendar Focus Sync/RELEASE.md
@@ -1,0 +1,16 @@
+### Internal Release Process
+
+1. Bump `CURRENT_PROJECT_VERSION` and `MARKETING_VERSION` in `Calendar Focus Sync.xcodeproj/project.pbxproj` to the new version number.
+2. Update the `CHANGELOG.md` with the new version number and changes.
+3. In XCode, Product > Archive, then Distribute App > App Store Connect > Upload
+
+## Direct Distribution
+
+1. In XCode, Product > Archive, then Distribute App > Custom > Copy App
+2. Use [create-dmg](https://github.com/sindresorhus/create-dmg) to create a DMG file for distribution
+
+```
+create-dmg Calendar\ Focus\ Sync.app/
+```
+
+3. Upload the DMG file to GitHub Releases

--- a/Calendar Focus Sync/Services/CalendarSync.swift
+++ b/Calendar Focus Sync/Services/CalendarSync.swift
@@ -45,6 +45,10 @@ class NativeCalendarSync: CalendarSyncer {
         // Declare event fetch parameters
         // TODO: Filter for specific calendars
         let calendars = store.calendars(for: .event)
+            // Exclude excluded calendars
+            .filter { calendar in
+                !UserPreferences.shared.excludedCalendarIds.contains(calendar.calendarIdentifier)
+            }
         
         // Fetch events
         let predicate = store.predicateForEvents(withStart: syncFilter.startDate, end: syncFilter.endDate, calendars: calendars)

--- a/Calendar Focus Sync/Services/SyncOrchestrator.swift
+++ b/Calendar Focus Sync/Services/SyncOrchestrator.swift
@@ -83,6 +83,7 @@ class SyncOrchestrator {
     func go() async {
         Task { @MainActor in
             AppState.shared.calendarEvents = await syncCalendarEvents()
+            AppState.shared.calendars = store.calendars(for: .event)
         }
     }
     

--- a/Calendar Focus Sync/State/AppState.swift
+++ b/Calendar Focus Sync/State/AppState.swift
@@ -1,11 +1,14 @@
 import Foundation
 import Combine
+import EventKit
 
 class AppState: ObservableObject {
     static let shared = AppState()
     
     @Published var isShortCutInstalled: Bool = false
     @Published var calendarEvents: [CalendarEvent] = []
+    @Published var calendars: [EKCalendar] = []
+    
         
     init() {
         self.isShortCutInstalled = isShortcutInstalled()

--- a/Calendar Focus Sync/State/UserPreferences.swift
+++ b/Calendar Focus Sync/State/UserPreferences.swift
@@ -22,6 +22,12 @@ class UserPreferences: ObservableObject {
     @Published var notificationsAccessGranted: Bool {
         didSet {
             defaults.set(notificationsAccessGranted, forKey: "notificationsAccessGranted")
+            
+            Task {
+                if nativeCalendarAccessGranted {
+                    await SyncOrchestrator.shared.go()
+                }
+            }
         }
     }
     
@@ -29,12 +35,31 @@ class UserPreferences: ObservableObject {
     @Published var selectedPriorTimeBuffer: Int {
         didSet {
             defaults.set(selectedPriorTimeBuffer, forKey: "selectedPriorTimeBuffer")
+            
+            Task {
+                if nativeCalendarAccessGranted {
+                    await SyncOrchestrator.shared.go()
+                }
+            }
         }
     }
-        
+    
+    @Published var excludedCalendarIds: [String] = [] {
+        didSet {
+            defaults.set(excludedCalendarIds, forKey: "excludedCalendarIds")
+            
+            Task {
+                if nativeCalendarAccessGranted {
+                    await SyncOrchestrator.shared.go()
+                }
+            }
+        }
+    }
+    
     init() {
         self.nativeCalendarAccessGranted = EKEventStore.authorizationStatus(for: .event) == .fullAccess
         self.selectedPriorTimeBuffer = defaults.integer(forKey: "selectedPriorTimeBuffer") != 0 ? defaults.integer(forKey: "selectedPriorTimeBuffer") : 5
         self.notificationsAccessGranted = defaults.bool(forKey: "notificationsAccessGranted")
+        self.excludedCalendarIds = defaults.object(forKey: "excludedCalendarIds") as? [String] ?? []
     }
 }


### PR DESCRIPTION
# Overview
Updates the UI and sync routines to support only triggering focus for events from specific calendars. Closes #1 

# What this looks like
![Screenshot 2024-05-18 at 20 37 42](https://github.com/a11rew/calendar-focus-sync/assets/87580113/b620f72b-92be-4a0c-afbd-8620162a9e7d)
